### PR TITLE
chore: use rollup-plugin-typescript2 to read rollup.config.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.ts --configPlugin rollup-plugin-typescript2",
     "clean": "rm -rf dist/ node_modules/",
     "lint": "prettier --check . && eslint --max-warnings 0 .",
     "start": "rollup -c rollup.config.js --watch",
@@ -37,7 +37,6 @@
     "@types/mongodb": "^3.6.20",
     "@types/node": "15.12.4",
     "esbuild": "0.12.9",
-    "esbuild-register": "2.6.0",
     "eslint": "7.29.0",
     "jest": "26.6.3",
     "jest-junit": "12.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,0 @@
-/* eslint-disable no-global-assign */
-require('esbuild-register');
-module.exports = require('./rollup.config.ts');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,15 +2545,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-register@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-2.6.0.tgz#9f19a54c82be751dd87673d6a66d7b9e1cdd8498"
-  integrity sha512-2u4AtnCXP5nivtIxZryiZOUcEQkOzFS7UhAqibUEmaTAThJ48gDLYTBF/Fsz+5r0hbV1jrFE6PQvPDUrKZNt/Q==
-  dependencies:
-    esbuild "^0.12.8"
-    jsonc-parser "^3.0.0"
-
-esbuild@0.12.9, esbuild@^0.12.8:
+esbuild@0.12.9:
   version "0.12.9"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.9.tgz#bed4e7087c286cd81d975631f77d47feb1660070"
   integrity sha512-MWRhAbMOJ9RJygCrt778rz/qNYgA4ZVj6aXnNPxFjs7PmIpb0fuB9Gmg5uWrr6n++XKwwm/RmSz6RR5JL2Ocsw==
@@ -4448,11 +4440,6 @@ jsonc-eslint-parser@^0.6.2:
   dependencies:
     eslint-visitor-keys "^1.3.0"
     espree "^6.0.0 || ^7.2.0"
-
-jsonc-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
-  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Replaces esbuild-register with rollup-plugin-typescript2.